### PR TITLE
chore: add dotenv to handle env variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^2.9.11",
+        "dotenv": "^16.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.43.2",
@@ -864,6 +865,14 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.312",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^2.9.11",
+    "dotenv": "^16.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.2",

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,4 +1,7 @@
 const Home = () => {
+  const sampleVar = import.meta.env.VITE_SAMPLE_VARIABLE
+  console.log(sampleVar);
+
   return (
     <div>
       <h1>Seemless Pipeline Home</h1>


### PR DESCRIPTION
- added .env file which is ignored
- uses library dotenv to access these
- has to be formatted for vite so variables are prepended with VITE
- sample variable is visible in Home component
- this uses a special import syntax